### PR TITLE
Fix global exception handling and tidy policy services

### DIFF
--- a/application/src/main/java/com/tinubu/insurance/application/exception/GlobalExceptionHandler.java
+++ b/application/src/main/java/com/tinubu/insurance/application/exception/GlobalExceptionHandler.java
@@ -4,13 +4,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
-import java.util.stream.Collectors;
-import org.axonframework.messaging.interceptors.ExceptionHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
@@ -21,19 +20,11 @@ public class GlobalExceptionHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(GlobalExceptionHandler.class);
   private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 
-  @ExceptionHandler(payloadType = MethodArgumentNotValidException.class)
-  public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
-      InvalidInputException ex, HttpServletRequest request) {
-    LOGGER.error("MethodArgumentNotValid: {}", ex.getMessage());
-    return buildErrorResponse(
-        HttpStatus.BAD_REQUEST, "Bad Request", ex.getMessage(), request.getRequestURI());
-  }
-
   /**
    * Handles custom ResourceNotFoundException (404 Not Found) Thrown when a requested resource does
    * not exist.
    */
-  @ExceptionHandler(payloadType = ResourceNotFoundException.class)
+  @ExceptionHandler(ResourceNotFoundException.class)
   public ResponseEntity<ErrorResponse> handleResourceNotFoundException(
       ResourceNotFoundException ex, HttpServletRequest request) {
     LOGGER.warn("Resource Not Found: {}", ex.getMessage());
@@ -45,7 +36,7 @@ public class GlobalExceptionHandler {
    * Handles custom InvalidInputException (400 Bad Request) Thrown for general bad input that
    * doesn't fit specific validation.
    */
-  @ExceptionHandler(payloadType = InvalidInputException.class)
+  @ExceptionHandler(InvalidInputException.class)
   public ResponseEntity<ErrorResponse> handleInvalidInputException(
       InvalidInputException ex, HttpServletRequest request) {
     LOGGER.warn("Invalid Input: {}", ex.getMessage());
@@ -57,7 +48,7 @@ public class GlobalExceptionHandler {
    * Handles MethodArgumentNotValidException (400 Bad Request) Thrown when @Valid or @Validated
    * fails for request body.
    */
-  @ExceptionHandler(payloadType = MethodArgumentNotValidException.class)
+  @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(
       MethodArgumentNotValidException ex, HttpServletRequest request) {
     List<ValidationError> validationErrors =
@@ -68,7 +59,7 @@ public class GlobalExceptionHandler {
                         .field(fieldError.getField())
                         .defaultMessage(fieldError.getDefaultMessage())
                         .build())
-            .collect(Collectors.toList());
+            .toList();
 
     String message = "Validation failed for request parameters.";
     LOGGER.warn("{}: {}", message, validationErrors);
@@ -77,14 +68,15 @@ public class GlobalExceptionHandler {
         HttpStatus.BAD_REQUEST,
         HttpStatus.BAD_REQUEST.getReasonPhrase(),
         message,
-        request.getRequestURI());
+        request.getRequestURI(),
+        validationErrors);
   }
 
   /**
    * Handles MethodArgumentTypeMismatchException (400 Bad Request) Thrown when method argument is
    * not of the expected type (e.g., UUID in path variable).
    */
-  @ExceptionHandler(payloadType = MethodArgumentTypeMismatchException.class)
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
   public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatch(
       MethodArgumentTypeMismatchException ex, HttpServletRequest request) {
     String message =
@@ -102,7 +94,7 @@ public class GlobalExceptionHandler {
    * Handles custom ServiceUnavailableException (503 Service Unavailable) Thrown for external
    * service dependencies issues or temporary outages.
    */
-  @ExceptionHandler(payloadType = ServiceUnavailableException.class)
+  @ExceptionHandler(ServiceUnavailableException.class)
   public ResponseEntity<ErrorResponse> handleServiceUnavailableException(
       ServiceUnavailableException ex, HttpServletRequest request) {
     LOGGER.error(
@@ -118,7 +110,7 @@ public class GlobalExceptionHandler {
    * Handles NoHandlerFoundException (404 Not Found for undefined endpoints) Make sure
    * 'spring.mvc.throw-exception-if-no-handler-found=true' is set in application.properties.
    */
-  @ExceptionHandler(payloadType = NoHandlerFoundException.class)
+  @ExceptionHandler(NoHandlerFoundException.class)
   public ResponseEntity<ErrorResponse> handleNoHandlerFoundException(
       NoHandlerFoundException ex, HttpServletRequest request) {
     LOGGER.warn("No Handler Found: {} {}", ex.getHttpMethod(), ex.getRequestURL());
@@ -133,7 +125,7 @@ public class GlobalExceptionHandler {
    * General fallback for any unhandled exceptions (500 Internal Server Error) Logs the full stack
    * trace for debugging.
    */
-  @ExceptionHandler(payloadType = Exception.class)
+  @ExceptionHandler(Exception.class)
   public ResponseEntity<ErrorResponse> handleAllUncaughtException(
       Exception ex, HttpServletRequest request) {
     LOGGER.error("An unexpected internal server error occurred: ", ex); // Log full stack trace

--- a/application/src/main/java/com/tinubu/insurance/application/service/PolicyCommandService.java
+++ b/application/src/main/java/com/tinubu/insurance/application/service/PolicyCommandService.java
@@ -7,8 +7,6 @@ import com.tinubu.insurance.application.exception.InvalidInputException;
 import com.tinubu.insurance.domain.policy.entity.PolicyId;
 import com.tinubu.insurance.domain.policy.entity.PolicyStatus;
 import java.time.LocalDate;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
@@ -68,8 +66,6 @@ public class PolicyCommandService {
    */
   public CompletableFuture<Void> updatePolicy(
       PolicyId policyId, String name, PolicyStatus status, LocalDate startDate, LocalDate endDate) {
-    // Build the command object (PolicyUpdatedEvent in this case)
-    OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
     UpdatePolicyCommand command =
         new UpdatePolicyCommand(policyId, name, status, startDate, endDate);
     logger.info("Sending command to update policy with ID: {}", policyId);

--- a/application/src/main/java/com/tinubu/insurance/application/service/PolicyQueryService.java
+++ b/application/src/main/java/com/tinubu/insurance/application/service/PolicyQueryService.java
@@ -6,9 +6,7 @@ import com.tinubu.insurance.application.queries.FindPolicyByIdQuery;
 import com.tinubu.insurance.domain.policy.entity.Policy;
 import com.tinubu.insurance.domain.policy.entity.PolicyId;
 import com.tinubu.insurance.domain.policy.port.PolicyRepository;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.axonframework.queryhandling.QueryHandler;
@@ -22,7 +20,6 @@ public class PolicyQueryService {
 
   private static final Logger logger = LoggerFactory.getLogger(PolicyQueryService.class);
 
-  private final Map<PolicyId, Policy> policyMap = new HashMap<>();
   private final PolicyRepository<Policy, UUID> policyRepository;
 
   @QueryHandler

--- a/infrastructure/src/main/java/com/tinubu/insurance/infrastructure/spi/aggregates/PolicyAggregate.java
+++ b/infrastructure/src/main/java/com/tinubu/insurance/infrastructure/spi/aggregates/PolicyAggregate.java
@@ -12,6 +12,7 @@ import com.tinubu.insurance.domain.policy.events.PolicyCreatedEvent;
 import com.tinubu.insurance.domain.policy.events.PolicyStatusUpdatedEvent;
 import com.tinubu.insurance.domain.policy.events.PolicyUpdatedEvent;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import lombok.Getter;
 import org.axonframework.commandhandling.CommandHandler;
 import org.axonframework.eventsourcing.EventSourcingHandler;
@@ -33,7 +34,7 @@ public class PolicyAggregate {
   @CommandHandler
   public PolicyAggregate(CreatePolicyCommand command) {
 
-    OffsetDateTime now = OffsetDateTime.now();
+    OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
 
     // Apply the creation event
     apply(
@@ -64,7 +65,7 @@ public class PolicyAggregate {
             command.status(),
             command.startDate(),
             command.endDate(),
-            OffsetDateTime.now()));
+            OffsetDateTime.now(ZoneOffset.UTC)));
   }
 
   @CommandHandler
@@ -84,7 +85,7 @@ public class PolicyAggregate {
               currentStatus,
               newStatus,
               command.reason(),
-              OffsetDateTime.now()));
+              OffsetDateTime.now(ZoneOffset.UTC)));
     }
   }
 

--- a/infrastructure/src/main/java/com/tinubu/insurance/infrastructure/spi/projection/PolicyProjection.java
+++ b/infrastructure/src/main/java/com/tinubu/insurance/infrastructure/spi/projection/PolicyProjection.java
@@ -131,7 +131,7 @@ public class PolicyProjection {
       return repository.findPoliciesNeedingStatusUpdate().stream().toList();
 
     } catch (Exception e) {
-      logger.error("Failed to handle FindAllPoliciesQuery", e);
+      logger.error("Failed to handle FindPoliciesNeedingStatusUpdateQuery", e);
       throw e;
     }
   }

--- a/presentation/src/main/java/com/tinubu/insurance/presentation/PolicyController.java
+++ b/presentation/src/main/java/com/tinubu/insurance/presentation/PolicyController.java
@@ -4,7 +4,6 @@ import com.tinubu.insurance.application.queries.FindAllPoliciesQuery;
 import com.tinubu.insurance.application.queries.FindPolicyByIdQuery;
 import com.tinubu.insurance.application.service.PolicyCommandService;
 import com.tinubu.insurance.application.service.PolicyQueryService;
-import com.tinubu.insurance.application.service.PolicyStatusSchedulerService;
 import com.tinubu.insurance.domain.policy.entity.Policy;
 import com.tinubu.insurance.domain.policy.entity.PolicyId;
 import com.tinubu.insurance.presentation.dto.CreatePolicyRequest;
@@ -33,8 +32,6 @@ public class PolicyController {
 
   private final PolicyCommandService commandService;
   private final PolicyQueryService queryService;
-  private final PolicyStatusSchedulerService schedulerService;
-
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)
   public void createPolicy(@Valid @RequestBody CreatePolicyRequest request) {


### PR DESCRIPTION
## Summary
- switch the exception handler advice to Spring's annotations and include validation error details in responses
- remove unused components from the policy controller and query service for leaner beans
- standardize policy aggregate timestamps to UTC and correct logging in the projection

## Testing
- `mvn test` *(fails: unable to download dependencies because Maven Central returns 403)*

------
